### PR TITLE
Fix processor loading for WER evaluation

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,3 +23,16 @@ python finetune_whisper.py --dataset_name mozilla-foundation/common_voice_11_0 -
 To store the downloaded dataset in a specific directory, add the `--dataset_cache_dir` option.
 
 The finetuned model will be saved to `whisper_finetuned` by default.
+
+## Evaluating word error rate
+
+After fine-tuning, you can evaluate the model using `culc_wer.py`:
+
+```bash
+python culc_wer.py --model_path path/to/checkpoint \
+                   --processor_path openai/whisper-small
+```
+
+The `--processor_path` argument should point to the base Whisper model
+whose tokenizer was used during training. If not specified, it defaults
+to `openai/whisper-small`.

--- a/culc_wer.py
+++ b/culc_wer.py
@@ -20,6 +20,11 @@ def parse_args():
         default="whisper_finetuned/checkpoint-3903",
         help="Path to the fine-tuned model",
     )
+    parser.add_argument(
+        "--processor_path",
+        default="openai/whisper-small",
+        help="Path or name of the processor to use (defaults to base Whisper model)",
+    )
     parser.add_argument("--use_gpu", action="store_true", help="Use GPU if available")
     return parser.parse_args()
 
@@ -36,7 +41,7 @@ def main():
     )
     dataset = dataset.cast_column("audio", Audio(sampling_rate=16000))
 
-    processor = WhisperProcessor.from_pretrained(args.model_path)
+    processor = WhisperProcessor.from_pretrained(args.processor_path)
     model = WhisperForConditionalGeneration.from_pretrained(args.model_path).to(device)
 
     text_column = None


### PR DESCRIPTION
## Summary
- add `--processor_path` argument to `culc_wer.py`
- load Whisper processor from a configurable path
- document how to evaluate WER in README

## Testing
- `python -m py_compile culc_wer.py`
- `python -m py_compile finetune_whisper.py`

------
https://chatgpt.com/codex/tasks/task_e_6846adfca6a083219aef4e3f919ba485