### PR TITLE
Fix forced decoder id error in culc_wer

### DIFF
--- a/culc_wer.py
+++ b/culc_wer.py
@@ -43,6 +43,15 @@ def main():
 
     processor = WhisperProcessor.from_pretrained(args.processor_path)
     model = WhisperForConditionalGeneration.from_pretrained(args.model_path).to(device)
+    # Disable forced decoder ids to avoid generation errors with newer versions
+    # of ``transformers``. Whisper models set ``forced_decoder_ids`` in their
+    # config which conflicts with the decoder prompts that ``generate``
+    # automatically prepares. Setting it to ``None`` ensures the model can
+    # generate from audio features without raising a ``ValueError``.
+    if hasattr(model, "generation_config"):
+        model.generation_config.forced_decoder_ids = None
+    else:
+        model.config.forced_decoder_ids = None
 
     text_column = None
     for col in ["sentence", "text", "transcript"]:


### PR DESCRIPTION
## Summary
- disable `forced_decoder_ids` when generating transcripts in `culc_wer.py`

## Testing
- `python -m py_compile culc_wer.py`
- `python culc_wer.py --help` *(fails: ModuleNotFoundError: No module named 'datasets')*

------
https://chatgpt.com/codex/tasks/task_e_6846b28eacf4832187c0bc4c3c9a549a