### PR TITLE
Add gold transcript feature option

### DIFF
--- a/dst_multipule_word/utils/prepare_feature.py
+++ b/dst_multipule_word/utils/prepare_feature.py
@@ -42,10 +42,12 @@ def prepare_feature(
         probs = torch.nn.functional.softmax(logits, dim=-1)
         batch["probs"] = probs
         return batch
-    dataset = dataset.map(
-        _generate,
-        load_from_cache_file=False,
-    )
+
+    if experiment_name != "gold":
+        dataset = dataset.map(
+            _generate,
+            load_from_cache_file=False,
+        )
     ## target_token_seqsの定義
     # キャッシュから読み込む
     with open("multiple_word_dataset/tokenizer_cache/tokenizer_cache_traindev.json", "r") as f:
@@ -54,29 +56,47 @@ def prepare_feature(
     with open("multiple_word_dataset/dictionary/slot_list.json", 'r') as f:
         slots_dic = json.load(f)
     def _culc_text_prob(batch: Dict) -> Dict:
-        # シーケンスごとの確率を求める
-        probs = batch["probs"]
+        # シーケンスごとの確率を求めるまたはゴールドテキストから特徴量を生成する
         feature = np.zeros(2 ** num_qubits, dtype=np.float32)
-        if experiment_name == "amplitude":
+        if experiment_name in ["amplitude", "1-best"]:
+            probs = batch["probs"]
+            if experiment_name == "amplitude":
+                for i, ids in target_token_seqs.items():
+                    prob = 1.0
+                    for step, token_id in enumerate(ids):
+                        if step >= len(probs[0]):
+                            break
+                        prob *= probs[0][step][token_id]
+                    feature[i] = prob
+            else:  # 1-best
+                max_value, max_index = 0, 0
+                for i, ids in target_token_seqs.items():
+                    prob = 1.0
+                    for step, token_id in enumerate(ids):
+                        if step >= len(probs[0]):
+                            break
+                        prob *= probs[0][step][token_id]
+                    if prob > max_value:
+                        max_value = prob
+                        max_index = i
+                feature[max_index] = 1.0
+        elif experiment_name == "gold":
+            token_ids = processor.tokenizer.encode(
+                batch["transcript"], add_special_tokens=False,
+                max_length=max_length, truncation=True
+            )
+            if len(token_ids) < max_length:
+                token_ids += [processor.tokenizer.pad_token_id] * (max_length - len(token_ids))
+            found = False
             for i, ids in target_token_seqs.items():
-                prob = 1.0
-                for step, token_id in enumerate(ids):
-                    if step >= len(probs[0]):
-                        break
-                    prob *= probs[0][step][token_id]
-                feature[i] = prob
-        elif experiment_name == "1-best":
-            max_value, max_index = 0, 0
-            for i, ids in target_token_seqs.items():
-                prob = 1.0
-                for step, token_id in enumerate(ids):
-                    if step >= len(probs[0]):
-                        break
-                    prob *= probs[0][step][token_id]
-                if prob > max_value:
-                    max_value = prob
-                    max_index = i
-            feature[max_index] = 1.0
+                if token_ids[:len(ids)] == ids:
+                    feature[i] = 1.0
+                    found = True
+                    break
+            if not found:
+                feature[0] = 1.0
+        else:
+            raise ValueError(f"Unknown experiment_name: {experiment_name}")
         # When all probabilities are zero, the feature vector becomes all zeros
         # which results in NaN during AmplitudeEmbedding normalization. Avoid
         # this by setting a small value to the first index so that the norm is


### PR DESCRIPTION
## Summary
- handle `experiment_name == "gold"` in `prepare_feature`
- skip Whisper inference when using ground truth transcripts
- convert gold transcripts to one-hot features with tokenizer

## Testing
- `python -m py_compile dst_multipule_word/utils/prepare_feature.py`

------
https://chatgpt.com/codex/tasks/task_e_688b02b3b3108321a150408488f9d795